### PR TITLE
Implement model-logic loader and re-implement model (As Transfomer)

### DIFF
--- a/src-server/maya.js
+++ b/src-server/maya.js
@@ -129,7 +129,9 @@ export default class Maya {
 
         // Model loader
         this._modelLoader = new ModelLoader(this.swapper, {
+            logger : this.logger,
             modelDir : path.join(this._options.appRoot, "models/"),
+            modelLogicsDir : path.join(this._options.appRoot, "logics/model-logic/"),
         });
 
         // database connector

--- a/src-server/model.js
+++ b/src-server/model.js
@@ -7,20 +7,42 @@ import Swappable from "./swappable";
 export default class Model extends Swappable
 {
     static create(proto) {
-        Model._setDefaults(proto);
-
-        const child = extend(proto, Model);
-        _.extend(child.prototype, Object.getPrototypeOf(Waterline.Collection.prototype));
-
-        return child;
+        const Child = extend(proto, Model);
+        return new Child();
     }
 
-    static _setDefaults(proto) {
-        proto.connection == null && (proto.connection = "default");
-    }
+    /**
+     * @property {}
+     */
 
-    constructor(waterline, connections, cb) {
-        super();
-        Waterline.Collection.call(this, waterline, connections, cb);
+    /**
+     * Transform Model to Waterline.Collection
+     * @param {Object} props method and properties for assignes collection.attributes
+     * @param {Object} staticProps method and properties for assignes collection (static).
+     * @return {Waterline.Collection}
+     */
+    toWaterlineCollection(props = {}, staticProps = {}) {
+        const schema = {};
+
+        _.defaults(schema, {
+            identity : this.identity,
+            schema : this.schema,
+            tableName : this.tableName,
+            connection : this.connection,
+            attributes : this.attributes,
+        }, {
+            identity : staticProps.identity,
+            schema : null,
+            tableName : null,
+            connection : "default",
+            attributes : {}
+        });
+
+        delete staticProps.identity;
+
+        _.extend(schema.attributes, props);
+        _.extend(schema, staticProps);
+
+        return Waterline.Collection.extend(schema);
     }
 }


### PR DESCRIPTION
`maya.Model` now works as transformer to `Waterline.Collection` from `maya.Model`.

Previous implementation (`maya.Model` works as `Waterline.Collection`) is bad compatibility for making customize Model.(Particularly with respect to implement `model-logic`).

It simplify to splits `maya.js layer` / `Waterline layer` Model implementation.